### PR TITLE
issue #24: resizing margin and padding on top and right

### DIFF
--- a/backend/src/Body.svelte
+++ b/backend/src/Body.svelte
@@ -10,7 +10,7 @@
 <section class="row">
   <Menu />
   <div class="col-9 col-md-offset-1 ">
-    <div class="mr-4 pt-5 pb-5" >
+    <div class="mr-1 pt-1 pb-1" >
       <Router>
         <Route path="/">
           <Home />


### PR DESCRIPTION
my first idea is to tune the main container in the Body.svelte, just reducing the local (inline) bootstrap margin and padding values. No global CSS involved, no risk of side effects on other components.     